### PR TITLE
Technical Correction FHIR-24434

### DIFF
--- a/resources/capabilitystatement-bulk-data.json
+++ b/resources/capabilitystatement-bulk-data.json
@@ -74,6 +74,38 @@
     {
       "mode": "server",
       "documentation": "The Bulk Data (Flat FHIR) Server **SHOULD**:\n\n1. Export data from a FHIR server whether or not it is associated with a patient. This supports use cases like backing up a server or exporting terminology data by restricting the resources returned using the _type parameter.\n1. Obtain data on all patients listed in a single FHIR Group Resource. If a FHIR server supports Group-level data export, it SHOULD support reading and searching for Group resource. This enables clients to discover available groups based on stable characteristics such as Group.identifier. Note: How these groups are defined is implementation specific for each FHIR system. For example, a payer may send a healthcare institution a roster file that can be imported into their EHR to create or update a FHIR group. Group membership could be based upon explicit attributes of the patient, such as: age, sex or a particular condition such as PTSD or Chronic Opioid use, or on more complex attributes, such as a recent inpatient discharge or membership in the population used to calculate a quality measure. FHIR-based group management is out of scope for the current version of this implementation guide.\n1. Export data from a FHIR server for all data associated with patients. This supports use cases like transmitting all data about patients or clinical care between systems.",
+      "resource": [
+        {
+          "type": "group",
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "group-export",
+              "definition": "OperationDefinition/GroupLevelExport"
+            }
+          ]
+        },
+        {
+          "type": "patient",
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient-export",
+              "definition": "OperationDefinition/PatientLevelExport"
+            }
+          ]
+        }
+      ],
       "security": {
         "description": "1. See the [Authorization Guide](authorization/index.html) section for requirements and recommendations.\n1. This specification describes requirements for requesting an access token
         through the use of an OAuth 2.0 client credentials flow, with a [JWT
@@ -90,26 +122,6 @@
           ],
           "name": "export",
           "definition": "OperationDefinition/BulkDataExport"
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-              "valueCode": "SHOULD"
-            }
-          ],
-          "name": "patient-export",
-          "definition": "OperationDefinition/PatientLevelExport"
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-              "valueCode": "SHOULD"
-            }
-          ],
-          "name": "group-export",
-          "definition": "OperationDefinition/GroupLevelExport"
         }
       ]
     }

--- a/spec/export/index.md
+++ b/spec/export/index.md
@@ -369,6 +369,9 @@ Required Fields:
       <td><span class="label label-info">optional</span></td>
       <td>JSON Object</td>
       <td>To support extensions, this implementation guide reserves the name <code>extension</code> and will never define a field with that name, allowing server implementations to use it to provide custom behavior and information. For example, a server may choose to provide a custom extension that contains a decryption key for encrypted ndjson files. The value of an extension element SHALL be a pre-coordinated JSON object.
+      <br/>
+      <br/>
+      Note: In addition to extensions being supported on the root object level, extensions may also be included within the fields above (e.g., in the 'output' object).
       </td>
     </tr>
   </tbody>

--- a/spec/operations/index.md
+++ b/spec/operations/index.md
@@ -10,4 +10,6 @@ These OperationDefinitions have been defined for this implementation guide.
 * [Patient Export: export patient data from a FHIR server](../OperationDefinition-patient-export.html)
 * [Group Export: export data for groups of patients from a FHIR server](../OperationDefinition-group-export.html)
 
-To declare conformance with this IG, a server should include the following URL in its own `CapabilityStatement.instantiates`: [http://www.hl7.org/fhir/bulk-data/CapabilityStatement-bulk-data.html](../CapabilityStatement-bulk-data.html)
+To declare conformance with this IG, a server should include the following URL in its own `CapabilityStatement.instantiates`: [http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data](../CapabilityStatement/bulk-data.html)
+
+Note - After an export is complete, a server MAY use DELETE as a signal that a client is done retrieving files and that it is safe for the sever to remove those from storage.

--- a/spec/operations/index.md
+++ b/spec/operations/index.md
@@ -11,5 +11,3 @@ These OperationDefinitions have been defined for this implementation guide.
 * [Group Export: export data for groups of patients from a FHIR server](../OperationDefinition-group-export.html)
 
 To declare conformance with this IG, a server should include the following URL in its own `CapabilityStatement.instantiates`: [http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data](../CapabilityStatement/bulk-data.html)
-
-Note - After an export is complete, a server MAY use DELETE as a signal that a client is done retrieving files and that it is safe for the sever to remove those from storage.


### PR DESCRIPTION
https://jira.hl7.org/plugins/servlet/mobile#issue/FHIR-24434

FHIR-24434 Technical corrections to bulk data conformance requirements

http://hl7.org/fhir/uv/bulkdata/operations/index.html: "To declare conformance with this IG, a server should include the following URL in its own CapabilityStatement.instantiates: http://www.hl7.org/fhir/bulk-data/CapabilityStatement-bulk-data.html" should say "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data (see http://hl7.org/fhir/uv/bulkdata/CapabilityStatement-bulk-data.json.html for details).
Also for technical correction: https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=23864

Would be good also to add a parenthetical on DELETE like "after an export is complete, a server MAY use DELETE as a signal that a client is done retrieving files and that it is safe for the sever to remove those from storage."
Also for technical correct: https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=24912