### PR TITLE
Argo - Group Membership - Option 2

### DIFF
--- a/spec/export/index.md
+++ b/spec/export/index.md
@@ -148,10 +148,11 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
     </tr>
     <tr>
       <td><code>_elements</code></td>
-      <td><span class="label label-info">optional</span></td>
+      <td><span class="label label-info">optional, exparimental</span></td>
       <td><span class="label label-info">optional</span></td>
       <td>string of comma-delimited FHIR Elements</td>
-      <td>When provided, the server SHOULD only include the listed elements in the resources returned. Elements should be of the form <code>[resource type].[element name]</code> (eg. <code>Patient.id</code>) or <code>[element name]</code> (eg. <code>id</code>) and only root elements in a resource are permitted. If the resource type is omitted, the element should be returned for all resources in the response where it is applicable..<br /><br />
+      <td>When provided, the server SHOULD omit unlisted, non-mandatory elements from the resources returned. Elements should be of the form <code>[resource type].[element name]</code> (eg. <code>Patient.id</code>) or <code>[element name]</code> (eg. <code>id</code>) and only root elements in a resource are permitted. If the resource type is omitted, the element should be returned for all resources in the response where it is applicable..<br /><br />
+        Servers are not obliged to return just the requested elements. Servers SHOULD always return mandatory elements whether they are requested or not. Servers SHOULD mark the resources with the tag SUBSETTED to ensure that the incomplete resource is not actually used to overwrite a complete resource.<br/><br/>
       Servers unable to support <code>_elements</code> SHOULD return an error and OperationOutcome resource so clients can re-submit a request omitting the <code>_elements</code> parameter.
       </td>
     </tr>
@@ -168,7 +169,7 @@ To obtain an new and updated resources for patients in a group, as well as all d
 
   - Client submits a group export request:
 
-    `[baseurl]/Group/[id]$export`
+    `[baseurl]/Group/[id]/$export`
 
   - Client retrieves response data
   - Client retains a list of the patient ids returned

--- a/spec/export/index.md
+++ b/spec/export/index.md
@@ -124,7 +124,7 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       <td><span class="label label-info">optional</span></td>
       <td><span class="label label-info">required</span></td>
       <td>FHIR instant</td>
-      <td>Resources will be included in the response if their state has changed after the supplied time (e.g.  if Resource.meta.lastUpdated is later than the supplied <code>_since</code> time). In the case of a Group level export, servers MAY return additional resources if the resource belongs to the patient compartment of a patient added to the Group after the supplied time (this behavior should be clearly documented  by the server).</td>
+      <td>Resources will be included in the response if their state has changed after the supplied time (e.g.  if Resource.meta.lastUpdated is later than the supplied <code>_since</code> time). In the case of a Group level export, servers MAY return additional resources modified prior to the supplied time if the resources belong to the patient compartment of a patient added to the Group after the supplied time (this behavior should be clearly documented  by the server).</td>
     </tr>
     <tr>
       <td><code>_type</code></td>

--- a/spec/export/index.md
+++ b/spec/export/index.md
@@ -114,7 +114,6 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       <td><code>_outputFormat</code></td>
       <td><span class="label label-info">required</span></td>
       <td><span class="label label-info">optional</span></td>
-      <td><span class="label label-info">required</span></td>
       <td>String</td>
       <td>The format for the requested bulk data files to be generated as per <a href="http://hl7.org/fhir/async.html">FHIR Asynchronous Request Pattern</a>. Defaults to <code>application/fhir+ndjson</code>. Servers SHALL support <a href="http://ndjson.org">Newline Delimited JSON</a>, but MAY choose to support additional output formats. Servers SHALL accept the full content type of <code>application/fhir+ndjson</code> as well as the abbreviated representations <code>application/ndjson</code> and <code>ndjson</code>.</td>
     </tr>
@@ -122,7 +121,6 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       <td><code>_since</code></td>
       <td><span class="label label-info">required</span></td>
       <td><span class="label label-info">optional</span></td>
-      <td><span class="label label-info">required</span></td>
       <td>FHIR instant</td>
       <td>Resources will be included in the response if their state has changed after the supplied time (e.g.  if Resource.meta.lastUpdated is later than the supplied <code>_since</code> time). In the case of a Group level export, servers MAY return additional resources modified prior to the supplied time if the resources belong to the patient compartment of a patient added to the Group after the supplied time (this behavior should be clearly documented  by the server).</td>
     </tr>
@@ -194,7 +192,7 @@ To obtain an new and updated resources for patients in a group, as well as all d
 
   - Client retains the transactionTime value from the response.
 
-##### Experimental Query Parameters
+#### Experimental Query Parameters
 
 As a community, we've identified use cases for finer-grained, client-specified filtering. For example, some clients may want to retrieve only active prescriptions (rather than historical prescriptions), or only laboratory observations (rather than all observations). We have considered several approaches to finer-grained filtering, including FHIR's `GraphDefinition`, the Clinical Quality Language (CQL), and FHIR's REST API search parameters. We expect this will be an area of active exploration, so for the time being this implementation guide defines an experimental syntax based on search parameters that works side-by-side with the coarse-grained `_type`-based filtering.
 
@@ -202,7 +200,7 @@ To request finer-grained filtering, a client MAY supply a `_typeFilter` paramete
 
 *Note for client developers*: Because both `_typeFilter` and `_since` can restrict the results returned, the interaction of these parameters may be surprising. Think carefully through the implications when constructing a query with both of these parameters. As the `_typeFilter` is experimental and optional, we have not yet determined expectation for `_include`, `_revinclude`, or support for any specific search parameters.
 
-###### Example Request with `_typeFilter`
+##### Example Request with `_typeFilter`
 
 The following is an export request for `MedicationRequest` resources and `Condition` resources, where the client would further like to restrict `MedicationRequests` to requests that are `active`, or else `completed` after July 1, 2018. This can be accomplished with two subqueries joined together with a comma for a logical "or":
 

--- a/spec/export/index.md
+++ b/spec/export/index.md
@@ -136,22 +136,22 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       For example <code>_type=Observation</code> could be used to filter a given export response to return only Observation resources.</td>
     </tr>
     <tr>
-      <td><code>patient</code></td>
-      <td><span class="label label-info">optional</span></td>
-      <td><span class="label label-info">optional</span></td>
-      <td>string of comma-delimited FHIR <a href="https://www.hl7.org/fhir/search.html#reference" target="_blank">reference search parameters</a></td>
-      <td>Not applicable to system level export requests. When provided, the server SHALL NOT return resources in the patient compartments belonging to patients outside of this list. If a client requests patients who do are not present on the server (or in the case of a group level export, who are not members of the group), the server SHOULD return details via an OperationOutcome resource in an error response to the request.<br /><br />
-      Servers unable to support <code>patient</code> SHOULD return an error and OperationOutcome resource so clients can re-submit a request omitting the <code>patient</code> parameter.
-      </td>
-    </tr>
-    <tr>
       <td><code>_elements</code></td>
-      <td><span class="label label-info">optional, exparimental</span></td>
+      <td><span class="label label-info">optional, experimental</span></td>
       <td><span class="label label-info">optional</span></td>
       <td>string of comma-delimited FHIR Elements</td>
       <td>When provided, the server SHOULD omit unlisted, non-mandatory elements from the resources returned. Elements should be of the form <code>[resource type].[element name]</code> (eg. <code>Patient.id</code>) or <code>[element name]</code> (eg. <code>id</code>) and only root elements in a resource are permitted. If the resource type is omitted, the element should be returned for all resources in the response where it is applicable..<br /><br />
         Servers are not obliged to return just the requested elements. Servers SHOULD always return mandatory elements whether they are requested or not. Servers SHOULD mark the resources with the tag SUBSETTED to ensure that the incomplete resource is not actually used to overwrite a complete resource.<br/><br/>
       Servers unable to support <code>_elements</code> SHOULD return an error and OperationOutcome resource so clients can re-submit a request omitting the <code>_elements</code> parameter.
+      </td>
+    </tr>
+    <tr>
+      <td><code>patient</code><br/>(POST requests only)</td>
+      <td><span class="label label-info">optional</span></td>
+      <td><span class="label label-info">optional</span></td>
+      <td>FHIR Reference</td>
+      <td>Not applicable to system level export requests. When provided, the server SHALL NOT return resources in the patient compartments belonging to patients outside of this list. If a client requests patients who do are not present on the server (or in the case of a group level export, who are not members of the group), the server SHOULD return details via an OperationOutcome resource in an error response to the request.<br /><br />
+      Servers unable to support <code>patient</code> SHOULD return an error and OperationOutcome resource so clients can re-submit a request omitting the <code>patient</code> parameter.
       </td>
     </tr>
   </tbody>

--- a/spec/export/index.md
+++ b/spec/export/index.md
@@ -114,13 +114,15 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       <td><code>_outputFormat</code></td>
       <td><span class="label label-info">required</span></td>
       <td><span class="label label-info">optional</span></td>
+      <td><span class="label label-info">required</span></td>
       <td>String</td>
-      <td>  The format for the requested bulk data files to be generated as per <a href="http://hl7.org/fhir/async.html">FHIR Asynchronous Request Pattern</a>. Defaults to <code>application/fhir+ndjson</code>. Servers SHALL support <a href="http://ndjson.org">Newline Delimited JSON</a>, but MAY choose to support additional output formats. Servers SHALL accept the full content type of <code>application/fhir+ndjson</code> as well as the abbreviated representations <code>application/ndjson</code> and <code>ndjson</code>.</td>
+      <td>The format for the requested bulk data files to be generated as per <a href="http://hl7.org/fhir/async.html">FHIR Asynchronous Request Pattern</a>. Defaults to <code>application/fhir+ndjson</code>. Servers SHALL support <a href="http://ndjson.org">Newline Delimited JSON</a>, but MAY choose to support additional output formats. Servers SHALL accept the full content type of <code>application/fhir+ndjson</code> as well as the abbreviated representations <code>application/ndjson</code> and <code>ndjson</code>.</td>
     </tr>
     <tr>
       <td><code>_since</code></td>
       <td><span class="label label-info">required</span></td>
       <td><span class="label label-info">optional</span></td>
+      <td><span class="label label-info">required</span></td>
       <td>FHIR instant</td>
       <td>Resources will be included in the response if their state has changed after the supplied time (e.g.  if Resource.meta.lastUpdated is later than the supplied <code>_since</code> time). In the case of a Group level export, servers MAY return additional resources if the resource belongs to the patient compartment of a patient added to the Group after the supplied time (this behavior should be clearly documented  by the server).</td>
     </tr>
@@ -138,15 +140,19 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
     <tr>
       <td><code>patient</code></td>
       <td><span class="label label-info">optional</span></td>
+      <td><span class="label label-info">optional</span></td>
       <td>string of comma-delimited FHIR <a href="https://www.hl7.org/fhir/search.html#reference" target="_blank">reference search parameters</a></td>
-      <td>Not applicable to system level export requests. When provided, the server SHALL NOT return resources in the patient compartments belonging to patients outside of this list. If a client requests patients who do are not present on the server (or in the case of a group level export, who are not members of the group), the server SHOULD return details via an OperationOutcome resource in an error response to the request.
+      <td>Not applicable to system level export requests. When provided, the server SHALL NOT return resources in the patient compartments belonging to patients outside of this list. If a client requests patients who do are not present on the server (or in the case of a group level export, who are not members of the group), the server SHOULD return details via an OperationOutcome resource in an error response to the request.<br /><br />
+      Servers unable to support <code>patient</code> SHOULD return an error and OperationOutcome resource so clients can re-submit a request omitting the <code>patient</code> parameter.
       </td>
     </tr>
     <tr>
       <td><code>_elements</code></td>
       <td><span class="label label-info">optional</span></td>
+      <td><span class="label label-info">optional</span></td>
       <td>string of comma-delimited FHIR Elements</td>
-      <td>When provided, the server SHOULD only include the listed elements in the resources returned. Elements should be of the form `[resource type].[element name]` (eg. `Patient.id`) or `[element name]` (eg. `id`) and only root elements in a resource are permitted. If the resource type is omitted, the element should be returned for all resources in the response where it is applicable.
+      <td>When provided, the server SHOULD only include the listed elements in the resources returned. Elements should be of the form <code>[resource type].[element name]</code> (eg. <code>Patient.id</code>) or <code>[element name]</code> (eg. <code>id</code>) and only root elements in a resource are permitted. If the resource type is omitted, the element should be returned for all resources in the response where it is applicable..<br /><br />
+      Servers unable to support <code>_elements</code> SHOULD return an error and OperationOutcome resource so clients can re-submit a request omitting the <code>_elements</code> parameter.
       </td>
     </tr>
   </tbody>
@@ -160,31 +166,32 @@ To obtain an new and updated resources for patients in a group, as well as all d
 
 - Initial Query (eg. on 1/1/2020):
 
-  1. Client submits a group export request:
+  - Client submits a group export request:
 
-      `[baseurl]\Group\[id]\$export`
+    `[baseurl]/Group/[id]$export`
 
-  2. Client retrieves response data
-  3. Client retains a list of the patient ids returned
-  4. Client retains the transactionTime value from the response
+  - Client retrieves response data
+  - Client retains a list of the patient ids returned
+  - Client retains the transactionTime value from the response
 
 - Subsequent Queries (eg. on 2/1/2020):
-  1. Client submits a group export request to obtain a patient list:
+  - Client submits a group export request to obtain a patient list:
 
-      `[baseurl]\Group\[id]\$export?_type=Patient&_elements=id`
+    `[baseurl]/Group/[id]/$export?_type=Patient&_elements=id`
 
-  2. Client retains a list of patient ids returned
-  3. Client compares response to patient ids from first query request and identifies new patient ids
-  4. Client submits a group export request for patients who are new members of the group: 
+  - Client retains a list of patient ids returned
+  - Client compares response to patient ids from first query request and identifies new patient ids
+  - Client submits a group export request for patients who are new members of the group: 
 
-      `[baseurl]\Group\[id]\$export?patient=[new1,new2,...]`
+    `[baseurl]/Group/[id]/$export?patient=[new1,new2,...]`
     
-  5. Client submits a group export request for updated group data: 
+  - Client submits a group export request for updated group data: 
 
-      `[baseurl]\Group\[id]\$export?_since=[initial transaction time]`
+    `[baseurl]/Group/[id]/$export?_since=[initial transaction time]`
+    
+    Note that data returned from this request may overlap with that returned from the prior step.
 
-  6. Client retains the transactionTime value from the response.
-  * Note that data returned in step 4 may overlap with data returned in step 5.
+  - Client retains the transactionTime value from the response.
 
 ##### Experimental Query Parameters
 

--- a/spec/export/index.md
+++ b/spec/export/index.md
@@ -180,9 +180,22 @@ To obtain an new and updated resources for patients in a group, as well as all d
 
   - Client retains a list of patient ids returned
   - Client compares response to patient ids from first query request and identifies new patient ids
-  - Client submits a group export request for patients who are new members of the group: 
+  - Client submits a group export request via POST for patients who are new members of the group: 
 
-    `[baseurl]/Group/[id]/$export?patient=[new1,new2,...]`
+    ```
+    POST [baseurl]/Group/[id]/$export
+    
+    {"resourceType" : "Parameters",
+      "parameter" : [{
+        "name" : "patient",
+        "valueReference" : {reference: "Patient/123"}
+      },{
+        "name" : "patient",
+        "valueReference" : {reference: "Patient/456"}
+      ...
+      }]
+    }
+    ```
     
   - Client submits a group export request for updated group data: 
 

--- a/spec/export/index.md
+++ b/spec/export/index.md
@@ -150,7 +150,7 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       <td><span class="label label-info">optional</span></td>
       <td><span class="label label-info">optional</span></td>
       <td>FHIR Reference</td>
-      <td>Not applicable to system level export requests. When provided, the server SHALL NOT return resources in the patient compartments belonging to patients outside of this list. If a client requests patients who do are not present on the server (or in the case of a group level export, who are not members of the group), the server SHOULD return details via an OperationOutcome resource in an error response to the request.<br /><br />
+      <td>Not applicable to system level export requests. When provided, the server SHALL NOT return resources in the patient compartments belonging to patients outside of this list. If a client requests patients who are not present on the server (or in the case of a group level export, who are not members of the group), the server SHOULD return details via an OperationOutcome resource in an error response to the request.<br /><br />
       Servers unable to support <code>patient</code> SHOULD return an error and OperationOutcome resource so clients can re-submit a request omitting the <code>patient</code> parameter.
       </td>
     </tr>


### PR DESCRIPTION
Addresses #65 in a way that supports groups that are only instantiated during requests to resolve them and do not track membership (eg. a query for patients with diabetes).

Open question: To handle large patient lists, this edit proposes adding support for initiating an export operation with a HTTP POST request of a FHIR Parameters object. Treating patients lists with search semantics (comma for "or"), will limit the maximum number of patients per request even via POST based on the maximum string size in FHIR (probably around 10k patients). Treating the patient list as a repeating parameter removes this limitation, but breaks with FHIR search semantics and means that the patient parameter won't work the same way as the current _type parameter. Options:

- Leave as is and have clients make multiple requests when querying for a large number of patient ids. This may be acceptable, particularly if many servers use the expanded `_since` param behavior to provide historical data on patients new to a group anyway.
- Use a repeating parameter for `patient` and change the `_type` parameter to match. This would be a breaking change. We could also use this opportunity to require POST when calling the operation - another breaking change.
- Create a new operation for patient scoped exports - eg. `export-subset` that uses repeating parameters for `patient` and `_type`.
- Use a repeating parameter for `patient`, but leave the `_type` parameter as a comma delimited list of values.
- Define different parameters for GET requests and POST requests. 