### PR TITLE
Fix ndjson url (https://jira.hl7.org/browse/FHIR-46497)

### DIFF
--- a/input/pagecontent/export.md
+++ b/input/pagecontent/export.md
@@ -13,7 +13,7 @@ The scope of this document does NOT include:
 ### Underlying Standards
 
 * [HL7 FHIR](https://www.hl7.org/fhir/)
-* [Newline-delimited JSON](http://ndjson.org)
+* [Newline-delimited JSON](https://github.com/ndjson/ndjson-spec)
 * [RFC5246, Transport Layer Security (TLS) Protocol Version 1.2](https://tools.ietf.org/html/rfc5246)
 * [RFC6749, The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)
 * [RFC6750, The OAuth 2.0 Authorization Framework: Bearer Token Usage](https://tools.ietf.org/html/rfc6750)


### PR DESCRIPTION
ndjson.org is now a gambling site 🙄 