### PR TITLE
FHIR-46524 - _typeFilter updates

### DIFF
--- a/input/fsh/extensions/OperationNotSupported.fsh
+++ b/input/fsh/extensions/OperationNotSupported.fsh
@@ -1,0 +1,7 @@
+Extension: OperationNotSupported
+Id: operation-not-supported
+Title: "Operation Not Supported"
+Description: "Used to indicate that the parent resource type or search parameter is not supported for use in a bulk data export operation."
+Context: "CapabilityStatement.rest.resource | CapabilityStatement.rest.resource.searchParam"
+* value[x] only canonical
+  * ^short = "Canonical URL for unsupported operation"

--- a/input/fsh/instances/export.fsh
+++ b/input/fsh/instances/export.fsh
@@ -57,5 +57,13 @@ Usage: #definition
   * use = #in
   * min = 0
   * max = "*"
-  * documentation = "Experimental - support is optional for a server and a client.\n\nString of comma-delimited FHIR REST search queries.\n\nWhen provided, a server with support for the parameter and requested search queries SHALL filter the data in the response to only include resources that meet the specified criteria. FHIR search response parameters such as `_include` and `_sort` SHALL NOT be used. \n\nA server that that is unable to support the requested `_typeFilter` queries SHOULD return an error and a FHIR `OperationOutcome` resource so the client can re-submit a request that omits those queries. When a `Prefer: handling=lenient` header is included in the request, the server MAY process the request instead of returning an error."
   * type = #string
+  * documentation = """
+    Support is optional for a server and a client.
+    
+    String of a FHIR REST search query.
+    
+    When provided, a server with support for the parameter and requested search queries SHALL filter the data in the response for resource types referenced in the typeFilter expression to only include resources that meet the specified criteria. FHIR search result parameters such as `_include` and `_sort` SHALL NOT be used and a query in the `_typeFilter` parameter SHALL have the search context of a single FHIR Resource Type.
+    
+    A server unable to support the requested `_typeFilter` queries SHOULD return an error and FHIR `OperationOutcome` resource so the client can re-submit a request that omits those queries. When a `Prefer: handling=lenient` header is included in the request, the server MAY process the request instead of returning an error.
+  """

--- a/input/fsh/instances/group-export.fsh
+++ b/input/fsh/instances/group-export.fsh
@@ -66,5 +66,13 @@ Usage: #definition
   * use = #in
   * min = 0
   * max = "*"
-  * documentation = "Experimental - support is optional for a server and a client.\n\nString of comma separated FHIR REST search queries.\n\nWhen provided, a server with support for the parameter and requested search queries SHALL filter the data in the response to only include resources that meet the specified criteria. FHIR search response parameters such as `_include` and `_sort` SHALL NOT be used. \n\nA server that that is unable to support the requested `_typeFilter` queries SHOULD return an error and a FHIR `OperationOutcome` resource so the client can re-submit a request that omits those queries. When a `Prefer: handling=lenient` header is included in the request, the server MAY process the request instead of returning an error."
   * type = #string
+  * documentation = """
+    Support is optional for a server and a client.
+    
+    String of a FHIR REST search query.
+    
+    When provided, a server with support for the parameter and requested search queries SHALL filter the data in the response for resource types referenced in the typeFilter expression to only include resources that meet the specified criteria. FHIR search result parameters such as `_include` and `_sort` SHALL NOT be used and a query in the `_typeFilter` parameter SHALL have the search context of a single FHIR Resource Type.
+    
+    A server unable to support the requested `_typeFilter` queries SHOULD return an error and FHIR `OperationOutcome` resource so the client can re-submit a request that omits those queries. When a `Prefer: handling=lenient` header is included in the request, the server MAY process the request instead of returning an error.
+  """

--- a/input/fsh/instances/patient-export.fsh
+++ b/input/fsh/instances/patient-export.fsh
@@ -66,5 +66,13 @@ Usage: #definition
   * use = #in
   * min = 0
   * max = "*"
-  * documentation = "Experimental - support is optional for a server and a client.\n\nString of comma separated FHIR REST search queries.\n\nWhen provided, a server with support for the parameter and requested search queries SHALL filter the data in the response to only include resources that meet the specified criteria. FHIR search response parameters such as `_include` and `_sort` SHALL NOT be used. \n\nA server that that is unable to support the requested `_typeFilter` queries SHOULD return an error and a FHIR `OperationOutcome` resource so the client can re-submit a request that omits those queries. When a `Prefer: handling=lenient` header is included in the request, the server MAY process the request instead of returning an error."
   * type = #string
+  * documentation = """
+    Support is optional for a server and a client.
+    
+    String of a FHIR REST search query.
+    
+    When provided, a server with support for the parameter and requested search queries SHALL filter the data in the response for resource types referenced in the typeFilter expression to only include resources that meet the specified criteria. FHIR search result parameters such as `_include` and `_sort` SHALL NOT be used and a query in the `_typeFilter` parameter SHALL have the search context of a single FHIR Resource Type.
+    
+    A server unable to support the requested `_typeFilter` queries SHOULD return an error and FHIR `OperationOutcome` resource so the client can re-submit a request that omits those queries. When a `Prefer: handling=lenient` header is included in the request, the server MAY process the request instead of returning an error.
+  """

--- a/input/images-source/processing-model.plantuml
+++ b/input/images-source/processing-model.plantuml
@@ -1,0 +1,36 @@
+@startuml
+start
+:All resources available for Bulk Export;
+:Exclude unauthorized resources
+(based on OAuth scopes and business logic);
+if (group export) then (yes)
+  :Exclude resources for patients outside group;
+else (no)
+endif
+if (`_type` parameter?) then (yes)
+  :Exclude resource of types not listed in `_type` parameter;
+else (no)
+endif
+if (`_since` parameter?) then (yes)
+  :Exclude resources updated prior to `_since` timestamp*;
+else (no)
+endif
+if (`_typeFilter` parameter?) then (yes)
+  repeat :for each resource type in export;
+  if (has `_typeFilter` criteria) then (yes)
+    :Exclude resources of this resource type 
+    that don't meet criteria in at least one 
+    of the `_typeFilter` parameters;
+  else (no)
+    :Retain all resources for this resource type;
+  endif
+  repeat while (additional resource types in export?);
+endif
+if (`includeAssociatedData` parameter) then (yes)
+  :Add associated resources for resources in export;
+else (no)
+endif
+:Add other related resources to provide context to those in export;
+:Output resources;
+stop
+@enduml

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -15,13 +15,6 @@ publisher:
   url: http://www.hl7.org/Special/committees/fiwg
   email: fhir@lists.HL7.org
 
-# this is a temporary fix and should be removed once publisher will build without it
-dependencies:
-  hl7.terminology.r4:
-    id: terminology
-    uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
-    version: 5.5.0
-
 pages:
   index.md:
     title: Home
@@ -66,3 +59,5 @@ resources:
 extension:
   - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-wg
     valueCode: fhir
+  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+    valueCode: trial-use


### PR DESCRIPTION
(1) Remove the use of `,` for logical OR and replace it with repeating the `_typeFilter` parameter. This is currently permitted by the parameter's 0..* cardinality, but does not have any documentation around the expected behavior.

(2) Add an approach to documenting search parameters in the capability statement that are supported by the server in other contexts, but not for _typeFilter in bulk export.

(3) Clarifications on which search result parameters are supported in _typeFilter.

(4) Document bulk export's logical processing model.