### PR TITLE
FHIR-49840 _until kick-off parameter

### DIFF
--- a/input/fsh/instances/export.fsh
+++ b/input/fsh/instances/export.fsh
@@ -29,6 +29,13 @@ Usage: #definition
   * documentation = "Support is required for a server, optional for a client.\n\nResources will be included in the response if their state has changed after the supplied time (e.g., if `Resource.meta.lastUpdated` is later than the supplied `_since` time). For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_since` value supplied by a client."
   * type = #instant
 * parameter[+]
+  * name = #_until
+  * use = #in
+  * min = 0
+  * max = "1"
+  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
+  * type = #instant
+* parameter[+]
   * name = #_type
   * use = #in
   * min = 0

--- a/input/fsh/instances/export.fsh
+++ b/input/fsh/instances/export.fsh
@@ -26,14 +26,14 @@ Usage: #definition
   * use = #in
   * min = 0
   * max = "1"
-  * documentation = "Support is required for a server, optional for a client.\n\nResources will be included in the response if their state has changed after the supplied time (e.g., if `Resource.meta.lastUpdated` is later than the supplied `_since` time). For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_since` value supplied by a client."
+  * documentation = "Support is required for a server, optional for a client.\n\nResources will be included in the response if their state has changed after the supplied time (e.g., if `Resource.meta.lastUpdated` is later than the supplied `_since` time). The server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_since` value supplied by a client."
   * type = #instant
 * parameter[+]
   * name = #_until
   * use = #in
   * min = 0
   * max = "1"
-  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
+  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). The server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
   * type = #instant
 * parameter[+]
   * name = #_type

--- a/input/fsh/instances/group-export.fsh
+++ b/input/fsh/instances/group-export.fsh
@@ -34,7 +34,7 @@ Usage: #definition
   * use = #in
   * min = 0
   * max = "1"
-  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
+  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). The server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
   * type = #instant
 * parameter[+]
   * name = #_type

--- a/input/fsh/instances/group-export.fsh
+++ b/input/fsh/instances/group-export.fsh
@@ -30,6 +30,13 @@ Usage: #definition
   * documentation = "Support is required for a server, optional for a client.\n\nResources will be included in the response if their state has changed after the supplied time (e.g., if `Resource.meta.lastUpdated` is later than the supplied `_since` time). A server MAY return additional resources modified prior to the supplied time if the resources belong to the patient compartment of a patient added to the group after the supplied time (this behavior SHOULD be clearly documented by the server). The server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_since` value supplied by a client."
   * type = #instant
 * parameter[+]
+  * name = #_until
+  * use = #in
+  * min = 0
+  * max = "1"
+  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
+  * type = #instant
+* parameter[+]
   * name = #_type
   * use = #in
   * min = 0

--- a/input/fsh/instances/patient-export.fsh
+++ b/input/fsh/instances/patient-export.fsh
@@ -30,6 +30,13 @@ Usage: #definition
   * documentation = "Support is required for a server, optional for a client.\n\nResources will be included in the response if their state has changed after the supplied time (e.g., if `Resource.meta.lastUpdated` is later than the supplied `_since` time). The server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_since` value supplied by a client."
   * type = #instant
 * parameter[+]
+  * name = #_until
+  * use = #in
+  * min = 0
+  * max = "1"
+  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
+  * type = #instant
+* parameter[+]
   * name = #_type
   * use = #in
   * min = 0

--- a/input/fsh/instances/patient-export.fsh
+++ b/input/fsh/instances/patient-export.fsh
@@ -34,7 +34,7 @@ Usage: #definition
   * use = #in
   * min = 0
   * max = "1"
-  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
+  * documentation = "Resources will be included in the response if their state has changed before the supplied time (e.g., if `Resource.meta.lastUpdated` is earlier than the supplied `_until` time). The server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the `_until` value supplied by a client."
   * type = #instant
 * parameter[+]
   * name = #_type

--- a/input/pagecontent/export.md
+++ b/input/pagecontent/export.md
@@ -144,7 +144,7 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       <td><span class="label label-info">optional</span></td>
       <td>0..1</td>
       <td>FHIR instant</td>
-      <td>Resources will be included in the response if their state has changed after the supplied time (e.g., if <code>Resource.meta.lastUpdated</code> is later than the supplied <code>_since</code> time). In the case of a Group level export, the server MAY return additional resources modified prior to the supplied time if the resources belong to the patient compartment of a patient added to the Group after the supplied time (this behavior SHOULD be clearly documented  by the server). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the <code>_since</code> value supplied by a client.</td>
+      <td>Resources will be included in the response if their state has changed after the supplied time (e.g., if <code>Resource.meta.lastUpdated</code> is later than the supplied <code>_since</code> time). In the case of a Group level export, the server MAY return additional resources modified prior to the supplied time if the resources belong to the patient compartment of a patient added to the Group after the supplied time (this behavior SHOULD be clearly documented  by the server). The server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the <code>_since</code> value supplied by a client.</td>
     </tr>
     <tr>
       <td><code>_until</code></td>
@@ -152,7 +152,7 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       <td><span class="label label-info">optional</span></td>
       <td>0..1</td>
       <td>FHIR instant</td>
-      <td>Resources will be included in the response if their state has changed before the supplied time (e.g., if <code>Resource.meta.lastUpdated</code> is earlier than the supplied <code>_until</code> time). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the <code>_until</code> value supplied by a client.</td>
+      <td>Resources will be included in the response if their state has changed before the supplied time (e.g., if <code>Resource.meta.lastUpdated</code> is earlier than the supplied <code>_until</code> time). The server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the <code>_until</code> value supplied by a client.</td>
     </tr>
     <tr>
       <td><code>_type</code></td>

--- a/input/pagecontent/export.md
+++ b/input/pagecontent/export.md
@@ -147,6 +147,14 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
       <td>Resources will be included in the response if their state has changed after the supplied time (e.g., if <code>Resource.meta.lastUpdated</code> is later than the supplied <code>_since</code> time). In the case of a Group level export, the server MAY return additional resources modified prior to the supplied time if the resources belong to the patient compartment of a patient added to the Group after the supplied time (this behavior SHOULD be clearly documented  by the server). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the <code>_since</code> value supplied by a client.</td>
     </tr>
     <tr>
+      <td><code>_until</code></td>
+      <td><span class="label label-info">optional</span></td>
+      <td><span class="label label-info">optional</span></td>
+      <td>0..1</td>
+      <td>FHIR instant</td>
+      <td>Resources will be included in the response if their state has changed before the supplied time (e.g., if <code>Resource.meta.lastUpdated</code> is earlier than the supplied <code>_until</code> time). For Patient- and Group-level requests, the server MAY return resources that are referenced by the resources being returned regardless of when the referenced resources were last updated. For resources where the server does not maintain a last updated time, the server MAY include these resources in a response irrespective of the <code>_until</code> value supplied by a client.</td>
+    </tr>
+    <tr>
       <td><code>_type</code></td>
       <td><span class="label label-info">optional</span></td>
       <td><span class="label label-info">optional</span></td>


### PR DESCRIPTION
Add support for an optional _until parameter on the Bulk Data kickoff request as an analog to the [_since parameter](https://hl7.org/fhir/uv/bulkdata/export.html#query-parameters) to enable users to specify a cutoff modification timestamp for the resources in the response. This is useful in cases like research studies that have approval to capture data from a specific time period, or for users who want to break a large export into sections. The capability has already been implemented in production servers under a variety of parameter names (for example, Microsoft's [_till parameter](https://learn.microsoft.com/en-us/azure/healthcare-apis/fhir/export-data#query-parameters) and the Regenstrief Institute's _until parameter), has been requested by implementers (for example, [CMS](https://chat.fhir.org/#narrow/stream/179250-bulk-data/topic/_endTime.20parameter/near/424954691)), and is included in IGs (for example [DaVinci ATR](https://build.fhir.org/ig/HL7/davinci-atr/OperationDefinition-davinci-data-export.html#parameters)).